### PR TITLE
PageIteratorImpl / PageImpl.listChildren bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build/
 .gradle/
+.idea/
 *.ipr
 *.iml
 *.iws

--- a/src/main/java/com/twcable/jackalope/impl/cq/PageImpl.java
+++ b/src/main/java/com/twcable/jackalope/impl/cq/PageImpl.java
@@ -21,6 +21,7 @@ import com.day.cq.commons.LabeledResource;
 import com.day.cq.tagging.Tag;
 import com.day.cq.tagging.TagManager;
 import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.PageFilter;
 import com.day.cq.wcm.api.PageManager;
 import com.day.cq.wcm.api.Template;
 import com.day.cq.wcm.api.WCMException;
@@ -75,19 +76,19 @@ public class PageImpl implements Page {
 
     @Override
     public Iterator<Page> listChildren() {
-        return listChildren(null);
+        return listChildren(new PageFilter());
     }
 
 
     @Override
     public Iterator<Page> listChildren(Filter<Page> pageFilter) {
-        return new PageIteratorImpl(resource, pageFilter);
+        return listChildren(pageFilter, false);
     }
 
 
     @Override
     public Iterator<Page> listChildren(Filter<Page> pageFilter, boolean deep) {
-        return new PageIteratorImpl(resource, pageFilter);
+        return new PageIteratorImpl(resource, pageFilter, deep);
     }
 
 

--- a/src/main/java/com/twcable/jackalope/impl/cq/PageIteratorImpl.java
+++ b/src/main/java/com/twcable/jackalope/impl/cq/PageIteratorImpl.java
@@ -33,17 +33,13 @@ public class PageIteratorImpl implements Iterator<Page> {
     private final Iterator<Page> iterator;
 
 
-    public PageIteratorImpl(Resource resource, Filter<Page> filter) {
-        List<Page> pages = new LinkedList<>();
-        for (Resource next : Lists.newArrayList(resource.listChildren())) {
-            Page page = next.adaptTo(Page.class);
-            if (page == null || !filter.includes(page)) continue;
-            pages.add(page);
-        }
-
-        this.iterator = pages.iterator();
+    public PageIteratorImpl(Resource resource, Filter<Page> filter, boolean deep) {
+        this.iterator = getChildren(resource, filter, deep).iterator();
     }
 
+    public PageIteratorImpl(Resource resource, Filter<Page> filter) {
+        this(resource, filter, false);
+    }
 
     @Override
     public boolean hasNext() {
@@ -60,5 +56,18 @@ public class PageIteratorImpl implements Iterator<Page> {
     @Override
     public void remove() {
         iterator.remove();
+    }
+
+    private List<Page> getChildren(Resource resource, Filter<Page> filter, boolean deep) {
+        List<Page> pages = new LinkedList<>();
+        for (Resource next : Lists.newArrayList(resource.listChildren())) {
+            Page page = next.adaptTo(Page.class);
+            if (page == null || !filter.includes(page)) continue;
+            pages.add(page);
+            if (deep) {
+                pages.addAll(getChildren(page.adaptTo(Resource.class), filter, true));
+            }
+        }
+        return pages;
     }
 }


### PR DESCRIPTION
- Fix bug where "deep" parameter to page.listChildren() is being ignored
- Fix bug page.listChildren() hits NPE due to having a null filter
