### PR TITLE
Fix issues w/trailing slash on node path

### DIFF
--- a/src/main/java/com/twcable/jackalope/impl/common/Paths.java
+++ b/src/main/java/com/twcable/jackalope/impl/common/Paths.java
@@ -160,4 +160,24 @@ public final class Paths {
     private static String stripRoot(String path) {
         return isAbsolute(path) ? path.substring(1) : path;
     }
+
+    /**
+     * Strip a trailing '/' on a path.
+     *
+     * Items saved in the JCR can be accessed as both /some/path and
+     * /some/path/ but the standard output is w/o the trailing '/'.
+     *
+     * Note that the root path '/' is preserved as '/'.
+     *
+     * @param path The path to be modified
+     * @return The path without a trailing '/' if one is found.
+     */
+    public static String stripTrailingSeparator(String path) {
+        if (path != null && !path.equals(SEPARATOR)) {
+            if (path.lastIndexOf(SEPARATOR) == (path.length() - 1)) {
+                return path.substring(0, path.length() - 1);
+            }
+        }
+        return path;
+    }
 }

--- a/src/main/java/com/twcable/jackalope/impl/jcr/ItemImpl.java
+++ b/src/main/java/com/twcable/jackalope/impl/jcr/ItemImpl.java
@@ -54,7 +54,7 @@ public abstract class ItemImpl implements Item {
      */
     ItemImpl(@Nonnull SessionImpl session, @Nonnull String path) throws ItemNotFoundException, ItemExistsException {
         this.session = session;
-        this.path = path;
+        this.path = Paths.stripTrailingSeparator(path);
         session.addItem(this);
     }
 
@@ -67,7 +67,7 @@ public abstract class ItemImpl implements Item {
 
 
     void setPath(String path) {
-        this.path = path;
+        this.path = Paths.stripTrailingSeparator(path);
     }
 
 

--- a/src/main/java/com/twcable/jackalope/impl/jcr/SessionImpl.java
+++ b/src/main/java/com/twcable/jackalope/impl/jcr/SessionImpl.java
@@ -149,19 +149,19 @@ public class SessionImpl implements Session {
 
     @Override
     public boolean itemExists(String absPath) {
-        return itemStore.containsKey(absPath);
+        return itemStore.containsKey(Paths.stripTrailingSeparator(absPath));
     }
 
 
     @Override
     public boolean nodeExists(String absPath) {
-        return itemExists(absPath) && itemStore.get(absPath).isNode();
+        return itemExists(absPath) && itemStore.get(Paths.stripTrailingSeparator(absPath)).isNode();
     }
 
 
     @Override
     public boolean propertyExists(String absPath) {
-        return itemExists(absPath) && !itemStore.get(absPath).isNode();
+        return itemExists(absPath) && !itemStore.get(Paths.stripTrailingSeparator(absPath)).isNode();
     }
 
 
@@ -353,7 +353,7 @@ public class SessionImpl implements Session {
 
 
     private ItemImpl getItemImpl(String absPath) {
-        return itemStore.get(absPath);
+        return itemStore.get(Paths.stripTrailingSeparator(absPath));
     }
 
 
@@ -364,6 +364,9 @@ public class SessionImpl implements Session {
 
 
     private void moveItem(String src, String dest) {
+        src = Paths.stripTrailingSeparator(src);
+        dest = Paths.stripTrailingSeparator(dest);
+
         ItemImpl item = itemStore.get(src);
         item.setPath(dest);
         itemStore.put(dest, item);

--- a/src/test/groovy/com/twcable/jackalope/impl/common/PathsSpec.groovy
+++ b/src/test/groovy/com/twcable/jackalope/impl/common/PathsSpec.groovy
@@ -169,4 +169,20 @@ class PathsSpec extends Specification {
         "/segment" | "next"    | "/segment/next"
         "/segment" | "/next"   | "/next"
     }
+
+    def "strip trailing separator"() {
+        expect:
+        Paths.stripTrailingSeparator(path) == expected
+
+        where:
+        path | expected
+        null             | null
+        "/"              | "/"
+        "/segment"       | "/segment"
+        "/segment/"      | "/segment"
+        "/segment/next"  | "/segment/next"
+        "/segment/next/" | "/segment/next"
+
+
+    }
 }


### PR DESCRIPTION
Fixed an issue where paths could be saved on nodes with or without a trailing slash as separate paths, and fetching with a trailing slash would not return a node without a trailing slash (which is different than how the real JCR session object works).  This bug was causing JcrUtil.createPath() to fail in tests b/c it fetches nodes with a path with a trailing /.
